### PR TITLE
Fix unsuppored optional chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Change unsuppored optional chaining from `options?.retries` to `(options && options.retries)`
+
 ## [1.1.0] - 2021-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.1] - 2021-08-18
+
 ### Fixed
 
 - Change unsuppored optional chaining from `options?.retries` to `(options && options.retries)`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/snyk-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A node.js client to interact with the Snyk api",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class SnykClient {
     }
 
     this.apiKey = apiKey;
-    this.retries = options?.retries || 5;
+    this.retries = (options && options.retries) || 5;
 
     this._request = request.defaults({
       baseUrl: SNYK_API_BASE,


### PR DESCRIPTION
```
### Fixed

- Change unsuppored optional chaining from `options?.retries` to `(options && options.retries)`